### PR TITLE
ensure pass is Boolean

### DIFF
--- a/src/matchers.js
+++ b/src/matchers.js
@@ -12,7 +12,7 @@ const partial = function (func) {
 }
 
 const passes = function (a, b) {
-  return (!a ^ !b)
+  return !!(!a ^ !b)
 }
 
 const compares = function (func) {


### PR DESCRIPTION
When jasmine-immutable-matchers use with jest, it will throw error:

```
    Unexpected return from a matcher function.
    Matcher functions should return an object in the following format:
      {message?: string | function, pass: boolean}
    '{"message": "Expected Map {} to be immutable", "pass": 1}' was returned
```